### PR TITLE
Use extras.RealDictCursor to return key value pairs

### DIFF
--- a/app/database/database.py
+++ b/app/database/database.py
@@ -1,6 +1,7 @@
 from flask import Flask
 from flask import current_app
 import psycopg2
+import psycopg2.extras
 class database:
     def connect():
         return psycopg2.connect(
@@ -14,7 +15,7 @@ class database:
     def select(query: str, vars):
         connection = database.connect()
 
-        cursor = connection.cursor()
+        cursor = connection.cursor(cursor_factory = psycopg2.extras.RealDictCursor)
         try:
             cursor.execute(query, vars)
             res = cursor.fetchall()


### PR DESCRIPTION
This PR changes the cursor factory to use one which returns key-value pairs.

Steps to replicate:
Confirm that, when selecting data via one of the endpoints, a the key is visible alongside the value instead of receiving an array.